### PR TITLE
fix: update docs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ember install ember-shepherd
 ```
 ## Documentation
 
-[View Docs](http://rwwagner90.github.io/ember-shepherd/)
+[View Docs](http://robbiethewagner.github.io/ember-shepherd/)
 
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "tour",
     "shepherd"
   ],
-  "homepage": "http://rwwagner90.github.io/ember-shepherd/",
+  "homepage": "http://robbiethewagner.github.io/ember-shepherd/",
   "repository": "https://github.com/rwwagner90/ember-shepherd",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
The repo url changed and so the docs are not accessible via the old links. You may change the URL in the repo description on GitHub as well. ;-)